### PR TITLE
Allow the webhook to mirror player deaths

### DIFF
--- a/src/main/java/net/modfest/utilities/config/Config.java
+++ b/src/main/java/net/modfest/utilities/config/Config.java
@@ -63,6 +63,10 @@ public class Config {
         return this.data.discord.token;
     }
 
+    public boolean shouldMirrorDeath() {
+        return this.data.discord.mirrorDeath;
+    }
+
     public String getName() {
         return this.data.server.name;
     }

--- a/src/main/java/net/modfest/utilities/data/ConfigData.java
+++ b/src/main/java/net/modfest/utilities/data/ConfigData.java
@@ -16,5 +16,6 @@ public class ConfigData {
         @Expose public String webhook = "";
         @Expose public String channel = "";
         @Expose public String token = "";
+        @Expose public boolean mirrorDeath = false;
     }
 }

--- a/src/main/java/net/modfest/utilities/mixin/ServerPlayerEntityMixin.java
+++ b/src/main/java/net/modfest/utilities/mixin/ServerPlayerEntityMixin.java
@@ -1,0 +1,31 @@
+package net.modfest.utilities.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.entity.damage.DamageSource;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.text.Text;
+import net.modfest.utilities.config.Config;
+import net.modfest.utilities.data.WebHookJson;
+import net.modfest.utilities.discord.WebHookUtil;
+
+@Mixin(ServerPlayerEntity.class)
+public class ServerPlayerEntityMixin {
+    @Inject(method = "onDeath", at = @At("TAIL"))
+    private void sendDeathMessage(DamageSource source, CallbackInfo info) {
+        if (!Config.getInstance().shouldMirrorDeath()) return;
+        if (Config.getInstance().getWebhook().isEmpty()) return;
+
+        Text displayName = ((PlayerEntity) (Object) this).getDisplayName();
+        if (source.getAttacker() instanceof PlayerEntity) {
+            Text attackerDisplayName = ((PlayerEntity) source.getAttacker()).getDisplayName();
+            WebHookUtil.send(WebHookJson.createSystem("**" + displayName.getString() + "** Died To **" + attackerDisplayName.getString() + "**."));
+        } else {
+            WebHookUtil.send(WebHookJson.createSystem("**" + displayName.getString() + "** Died."));
+        }
+    }
+}

--- a/src/main/resources/modfestutilities.mixins.json
+++ b/src/main/resources/modfestutilities.mixins.json
@@ -8,7 +8,8 @@
     "PlayerManagerMixin"
   ],
   "server": [
-    "MinecraftDedicatedServerMixin"
+    "MinecraftDedicatedServerMixin",
+    "ServerPlayerEntityMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
The pull request adds a configurable (disabled by default) option to allow the webhook to mirror death messages. The following messages are added:

- '**Player** Died.'
- '**Player** Died to **Attacker**.'