### PR TITLE
Make sending discord webhooks async to not block the server thread

### DIFF
--- a/src/main/java/net/modfest/utilities/ModFestUtilities.java
+++ b/src/main/java/net/modfest/utilities/ModFestUtilities.java
@@ -23,6 +23,7 @@ import org.apache.logging.log4j.Logger;
 import javax.security.auth.login.LoginException;
 import java.io.IOException;
 import java.util.Collections;
+import java.util.concurrent.ExecutionException;
 
 public class ModFestUtilities implements ModInitializer {
 
@@ -98,9 +99,9 @@ public class ModFestUtilities implements ModInitializer {
             if (respBody != null) {
                 HasteBinResponse haste = GSON.fromJson(respBody.string(), HasteBinResponse.class);
                 LOGGER.info("[ModFest] Crash report available at: https://hastebin.com/" + haste.key);
-                WebHookUtil.send(WebHookJson.createSystem("The server has crashed!\nReport: https://hastebin.com/" + haste.key));
+                WebHookUtil.send(WebHookJson.createSystem("The server has crashed!\nReport: https://hastebin.com/" + haste.key)).get();
             }
-        } catch (IOException e) {
+        } catch (IOException | ExecutionException | InterruptedException e) {
             ModFestUtilities.LOGGER.warn("[ModFest] Crash log failed to send.", e);
         }
     }

--- a/src/main/java/net/modfest/utilities/discord/WebHookUtil.java
+++ b/src/main/java/net/modfest/utilities/discord/WebHookUtil.java
@@ -1,24 +1,34 @@
 package net.modfest.utilities.discord;
 
+import net.minecraft.util.Unit;
+
 import net.modfest.utilities.ModFestUtilities;
 import net.modfest.utilities.config.Config;
 import net.modfest.utilities.data.WebHookJson;
 import okhttp3.*;
 
 import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
 
 public class WebHookUtil {
+    public static CompletableFuture<Unit> send(WebHookJson json) {
+        if (Config.getInstance().getWebhook().isEmpty()) {
+            return CompletableFuture.completedFuture(Unit.INSTANCE);
+        }
 
-    public static void send(WebHookJson json) {
-        if(Config.getInstance().getWebhook().isEmpty()) return;
-        RequestBody body = RequestBody.create(MediaType.get("application/json; charset=utf-8"), ModFestUtilities.GSON.toJson(json));
-        Request request = new Request.Builder()
+        return CompletableFuture.supplyAsync(() -> {
+            RequestBody body = RequestBody.create(MediaType.get("application/json; charset=utf-8"), ModFestUtilities.GSON.toJson(json));
+            Request request = new Request.Builder()
                 .url(Config.getInstance().getWebhook())
                 .post(body)
                 .build();
-        try (Response response = ModFestUtilities.client.newCall(request).execute()) {
-        } catch (IOException e) {
-            ModFestUtilities.LOGGER.warn("[ModFest] Failed to send message to discord.", e);
-        }
+
+            try (Response response = ModFestUtilities.client.newCall(request).execute()) {
+            } catch (IOException e) {
+                ModFestUtilities.LOGGER.warn("[ModFest] Failed to send message to discord.", e);
+            }
+
+            return Unit.INSTANCE;
+        });
     }
 }


### PR DESCRIPTION
I haven't tested it... but it should work. The only place where it does wait for the future to complete is when sending the crash report.
